### PR TITLE
[feature] [APPROXIMATION] Keep search bar filter when switching tabs

### DIFF
--- a/GalarDexTracker/MainPage.js
+++ b/GalarDexTracker/MainPage.js
@@ -52,6 +52,9 @@ export default class MainPage extends Component {
     this.setState({baseGameDisplay : "Base Game"})
     this.setState({data : ArmorPokedex}, () => this.setState({isleArmorDisplay : this.state.data.length + "/ 211"}))
     this.setState({filterData : ArmorPokedex})
+    if (this.state.text) {
+      this.searchFilterFunction(this.state.text);
+    }
   }
 
   DisableDLCPokemon = () => {
@@ -59,6 +62,9 @@ export default class MainPage extends Component {
     this.setState({isleArmorDisplay : "Isle of Armor"})
     this.setState({data : Pokedex}, () => this.setState({baseGameDisplay : this.state.data.length + "/ 400"}))
     this.setState({filterData : Pokedex})
+    if (this.state.text) {
+      this.searchFilterFunction(this.state.text);
+    }
   }
 
   showSearchHelpAlert = () => {

--- a/GalarDexTracker/TypeTagList.js
+++ b/GalarDexTracker/TypeTagList.js
@@ -89,7 +89,7 @@ export default class PokedexList extends Component {
     //Not a dual type
     var counter = 0;
 
-    for (i = 0; i < 18; i++)
+    for (let i = 0; i < 18; i++)
     {
       var typeval = "";
       var currentval = "";


### PR DESCRIPTION
#10 

calling the filtering function on
 - `EnableDLCPokemon()`
 - `DisableDLCPokemon()`

note: Please keep in mind that I'm not familiar with this code base;
consider this only an **approximation**, something like _**"ey, I think this could be the way when I read your code, but you know it better ^^"**_

------

## NOT READY TO MERGE

This isn't working as expected: it is needed to double tab for getting the filtered pokemon list. 


### suggestion

If I may, I have a suggestion: you can use [`React.useState()` hook](https://reactjs.org/docs/hooks-state.html) for doing some refactoring: 

On component creation you fetch both Pokemon lists and store them:

```js
const [baseGamePoke, setBaseGamePoke] = React.useState([]);
const [armorPoke, setArmorPoke] = React.useState([]);
```

```js
React.useEffect(() => {
        let isSubscribed = true;
        fetchPokemon().then(items => {
            if (isSubscribed) {
              // some coding here for obtaining both arrays
              setBaseGamePoke( /* [....] */ );
              setArmorPoke( /* [...] */ );
            }
        });
        const cleanUp = () => {
            isSubscribed = false;
        };
        return cleanUp;
    }, []); // will execute on component did mount
```

having that working will grant you the simplest filtering ever !!!! :), something like:

```js
 const [filterValue, setFilterValue] = React.useState('');
const [filteredBaseGamePokemon, setFilteredBaseGamePokemon] = React.useState([])
const [filteredArmourPokemon, setFilteredArmourPokemon] = React.useState([])

    React.useEffect(() => {
        if (filterFn && arePokemonReady) {
                const filteredBaseGamePokemon = [
                    ....filter(pk => filterFn()),
                ];
                ...
                setFilteredBaseGamePokemon(filteredBaseGamePokemon);
                ....
            } 
        }
    }, [filterValue]); // execute when the search bar changes

```

Now, you may show in the list `filteredBaseGamePokemon` and `filteredArmourPokemon` (instead of baseGamePoke which you want to keep fresh for filtering) 